### PR TITLE
Resolve Timer issue not reporting ticks

### DIFF
--- a/arch/arm/cpu/armv7/socfpga-common/timer.c
+++ b/arch/arm/cpu/armv7/socfpga-common/timer.c
@@ -80,14 +80,14 @@ ulong get_timer_masked(void)
 {
 	/* current tick value */
 	ulong now = read_timer() /
-		(CONFIG_TIMER_CLOCK_KHZ * 1000 / CONFIG_SYS_HZ);
+		(CONFIG_TIMER_CLOCK_HZ / CONFIG_SYS_HZ);
 	if (gd->arch.lastinc >= now) {
 		/* normal mode (non roll) */
 		/* move stamp forward with absolute diff ticks */
 		gd->arch.tbl += gd->arch.lastinc - now;
 	} else {
 		/* we have overflow of the count down timer */
-		gd->arch.tbl += (TIMER_LOAD_VAL / (CONFIG_TIMER_CLOCK_KHZ * 1000
+		gd->arch.tbl += (TIMER_LOAD_VAL / (CONFIG_TIMER_CLOCK_HZ
 			/ CONFIG_SYS_HZ)) - now + gd->arch.lastinc;
 	}
 	gd->arch.lastinc = now;
@@ -101,7 +101,7 @@ void reset_timer(void)
 {
 	/* capture current decrementer value time */
 	gd->arch.lastinc = read_timer() /
-		(CONFIG_TIMER_CLOCK_KHZ * 1000 / CONFIG_SYS_HZ);
+		(CONFIG_TIMER_CLOCK_HZ / CONFIG_SYS_HZ);
 	/* start "advancing" time stamp from 0 */
 	gd->arch.tbl = 0;
 }
@@ -150,6 +150,6 @@ void reset_timer_count(void)
  */
 unsigned long long get_ticks(void)
 {
-	return get_timer(0);
+	return get_timer_count(0);
 }
 


### PR DESCRIPTION
Original timer get_ticks() implementation has been using get_timer() value,
which does not return the actual timer ticks, rather than msec value.

When get_ticks() is used together with endtick() macro - this creates a
big time span, since endtick() uses the timer base value in ticks per second,
which is configured to the L4 frequency.

Practically, any wait in the system becomes an eternity, since msec value
returned from the get_ticks() function when added to a base (which is in ticks)
creates a very long span.

Corrected version of get_ticks() acquires the raw timer ticks via
get_timer_count() call.

Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>