### PR TITLE
Fix when SKIP_CFGIO and HANDHSHAKE_SDRAM are unset

### DIFF
--- a/arch/arm/cpu/armv7/socfpga/spl.c
+++ b/arch/arm/cpu/armv7/socfpga/spl.c
@@ -47,6 +47,8 @@ DECLARE_GLOBAL_DATA_PTR;
 #if (CONFIG_PRELOADER_WARMRST_SKIP_CFGIO == 1) || \
 (CONFIG_HPS_RESET_WARMRST_HANDSHAKE_SDRAM == 1)
 u32 rst_mgr_status;
+#else
+static const u32 rst_mgr_status = RSTMGR_COLDRST_MASK;
 #endif
 
 #ifdef CONFIG_SPL_FPGA_LOAD


### PR DESCRIPTION
When compiling with CONFIG_PRELOADER_WARMRST_SKIP_CFGIO == 0 and CONFIG_HPS_RESET_WARMRST_HANDSHAKE_SDRAM == 0 the compilation failed:
```c
spl.c: In function 'spl_board_init':
spl.c:444:4: error: 'rst_mgr_status' undeclared (first use in this function)
   (rst_mgr_status & RSTMGR_COLDRST_MASK) != 0) {
    ^~~~~~~~~~~~~~
```
We could #ifdef all the if condition where rst_mgr_status is used but it's start to be unreadable or we can assume that we are always in COLDRST so both SDRAM and CFGIO are reconfigured what we want here.