### PR TITLE
After the merge of socfpga_v2014.10_arria10_bringup last commit

### DIFF
--- a/arch/arm/cpu/armv7/socfpga_arria10/cff.c
+++ b/arch/arm/cpu/armv7/socfpga_arria10/cff.c
@@ -29,12 +29,16 @@ static int cff_flash_read(struct cff_flash_info *cff_flashinfo, u32 *buffer,
 	u32 *buffer_sizebytes);
 static int cff_flash_preinit(struct cff_flash_info *cff_flashinfo,
 	fpga_fs_info *fpga_fsinfo, u32 *buffer, u32 *buffer_sizebytes);
+
+static int fpga_ok = 0;
+
 static int cff_flash_probe(struct cff_flash_info *cff_flashinfo)
 {
 #ifdef CONFIG_CADENCE_QSPI
 	/* initialize the Quad SPI controller */
 	cff_flashinfo->raw_flashinfo.flash =
-		spi_flash_probe(0, 0, CONFIG_SF_DEFAULT_SPEED, SPI_MODE_3);
+	spi_flash_probe(CONFIG_SPI_FLASH_BUS, CONFIG_SPI_FLASH_CS, \
+		 			CONFIG_SF_DEFAULT_SPEED, SPI_MODE_3);
 
 	if (!(cff_flashinfo->raw_flashinfo.flash)) {
 		puts("SPI probe failed.\n");
@@ -342,8 +346,10 @@ int cff_from_flash(fpga_fs_info *fpga_fsinfo)
 	ret = cff_flash_preinit(&cff_flashinfo, fpga_fsinfo, &buffer,
 		&buffer_sizebytes);
 
-	if (ret)
+	if (ret) {
+		fpga_ok = ret;
 		return ret;
+	}
 
 	if (!strcmp(fpga_fsinfo->rbftype, "periph") ||
 		!strcmp(fpga_fsinfo->rbftype, "combined")) {
@@ -729,3 +735,6 @@ int socfpga_loadfs(Altera_desc *desc, const void *buf, size_t bsize,
 }
 #endif
 
+int is_fpga_ok() {
+	return fpga_ok;
+}

--- a/arch/arm/cpu/armv7/socfpga_arria10/misc.c
+++ b/arch/arm/cpu/armv7/socfpga_arria10/misc.c
@@ -173,10 +173,15 @@ void skip_relocation(void)
 	puts("DRAM  : ");
 	print_size(size, "\n");
 
+	if(size) {
 	/* relocate malloc at SDRAM to support eth */
-	gd->relocaddr = gd->ram_size;
+		gd->relocaddr = gd->ram_size;
 	/* relocate stack to SDRAM too where its located below malloc */
-	gd->start_addr_sp = gd->relocaddr - TOTAL_MALLOC_LEN;
+		gd->start_addr_sp = gd->relocaddr - TOTAL_MALLOC_LEN;
+	} else {
+		gd->relocaddr = CONFIG_SYS_TEXT_BASE + CONFIG_SYS_INIT_RAM_SIZE;
+		gd->start_addr_sp = gd->relocaddr - TOTAL_MALLOC_LEN;
+	}
 	gd->reloc_off = 0;
 	debug("relocation Offset is: %08lx\n", gd->reloc_off);
 

--- a/arch/arm/include/asm/arch-socfpga_arria10/cff.h
+++ b/arch/arm/include/asm/arch-socfpga_arria10/cff.h
@@ -49,6 +49,7 @@ int cff_from_qspi_env(void);
 int cff_from_flash(fpga_fs_info *fpga_fsinfo);
 int cff_from_nand_env(void);
 const char *get_cff_filename(const void *fdt, int *len);
+int is_fpga_ok(void);
 #endif /* __ASSEMBLY__ */
 
 #endif /* _SOCFPGA_CFF_H_ */


### PR DESCRIPTION
After the merge of socfpga_v2014.10_arria10_bringup last commit to our project branch (18 commits behind) an issue appeared with an "empty boards". The boards repeatedly resets
and it cannot be made operational. The only workaround was to use old
u-boot version, program the FPGA and then update the u-boot. My proposal
is to avoid not available DDR locations if FPGA configuration (e.g. DDR)
is not present or damaged. 

Signed-off-by: Georgi Georgiev <georgi.georgiev@woodward.com>