### PR TITLE
include: configs: soc64: set correct QSPI clock for Agilex plaform

### DIFF
--- a/include/configs/socfpga_soc64_common.h
+++ b/include/configs/socfpga_soc64_common.h
@@ -171,8 +171,10 @@ unsigned int cm_get_qspi_controller_clk_hz(void);
 		"fdt set /soc/spi@ff8d2000 status okay;" \
 		"if fdt set /soc/clocks/qspi-clk clock-frequency" \
 		" ${qspi_clock}; then" \
+		" else if fdt set /clocks/qspi-clk clock-frequency" \
+		" ${qspi_clock}; then" \
 		" else fdt set /soc/clkmgr/clocks/qspi_clk clock-frequency" \
-		" ${qspi_clock}; fi; fi\0" \
+		" ${qspi_clock}; fi; fi; fi\0" \
 	"scriptaddr=0x05FF0000\0" \
 	"scriptfile=boot.scr\0" \
 	"nandroot=ubi0:rootfs\0" \
@@ -222,8 +224,10 @@ unsigned int cm_get_qspi_controller_clk_hz(void);
 		"fdt set /soc/spi@ff8d2000 status okay;" \
 		"if fdt set /soc/clocks/qspi-clk clock-frequency" \
 		" ${qspi_clock}; then" \
+		" else if fdt set /clocks/qspi-clk clock-frequency" \
+		" ${qspi_clock}; then" \
 		" else fdt set /soc/clkmgr/clocks/qspi_clk clock-frequency" \
-		" ${qspi_clock}; fi; fi\0" \
+		" ${qspi_clock}; fi; fi; fi\0" \
 	"scriptaddr=0x02100000\0" \
 	"scriptfile=u-boot.scr\0" \
 	"fatscript=if fatload mmc 0:1 ${scriptaddr} ${scriptfile};" \


### PR DESCRIPTION
upstream kernel commit d2e593084270 ("arm64: dts: intel: socfpga_agilex:
move clocks out of soc node") has move qspi-clock out of soc node,
adjust linux_qspi_enable command accordingly.

Signed-off-by: Liwei Song <liwei.song@windriver.com>

seems that the reference code isn't included in u-boot upstream, so send the pull request here,
could you help review it? 
Thanks,
Liwei.


Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
