### PR TITLE
use spl_mmc_boot_mode instead of spl_boot_mode

### DIFF
--- a/arch/arm/mach-socfpga/spl_soc64.c
+++ b/arch/arm/mach-socfpga/spl_soc64.c
@@ -77,7 +77,7 @@ fallback:
 }
 
 #if IS_ENABLED(CONFIG_SPL_MMC)
-u32 spl_mmc_boot_mode(const u32 boot_device)
+u32 spl_mmc_boot_mode(struct mmc *mmc, const u32 boot_device)
 {
 #if defined(CONFIG_SPL_FS_FAT) || defined(CONFIG_SPL_FS_EXT4)
 	return MMCSD_MODE_FS;

--- a/arch/arm/mach-socfpga/spl_soc64.c
+++ b/arch/arm/mach-socfpga/spl_soc64.c
@@ -77,7 +77,7 @@ fallback:
 }
 
 #if IS_ENABLED(CONFIG_SPL_MMC)
-u32 spl_boot_mode(const u32 boot_device)
+u32 spl_mmc_boot_mode(const u32 boot_device)
 {
 #if defined(CONFIG_SPL_FS_FAT) || defined(CONFIG_SPL_FS_EXT4)
 	return MMCSD_MODE_FS;


### PR DESCRIPTION
Per spl_mmc_boot_mode() - Lookup function for the mode of an MMC boot source: spl_boot_mode is not a valid name and is not used in u-boot. The correct name is spl_mmc_boot_mode.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
