### PR TITLE
arch: mach-socfpga: cv_bsp_generator: fix support for Python3

### DIFF
--- a/arch/arm/mach-socfpga/cv_bsp_generator/hps.py
+++ b/arch/arm/mach-socfpga/cv_bsp_generator/hps.py
@@ -411,7 +411,7 @@ class HPSGrokker(object):
                     configNode = xmlgrok.nextElementSibling(configNode)
                     if configNode == None:
                         newLine += newLine
-                    self.pinmuxConfigBuffer.write("#define " + unicode(config_define_name) + ' ' + '(' + str(config_define_value) + ')' + newLine)
+                    self.pinmuxConfigBuffer.write("#define " + str(config_define_name) + ' ' + '(' + str(config_define_value) + ')' + newLine)
 
                 entry = self.pinmux_configs[name]
                 define_name = entry['name']
@@ -436,7 +436,7 @@ class HPSGrokker(object):
     def handleHPSPinmuxesNode(self, pinmuxesNode):
         """ PinmuxesNode is a list of pinmuxNodes
         """
-        self.pinmuxHeaderBuffer.write( unicode("const u8 sys_mgr_init_table[] = {\n"))
+        self.pinmuxHeaderBuffer.write( str("const u8 sys_mgr_init_table[] = {\n"))
 
         pinmuxNode = xmlgrok.firstElementChild(pinmuxesNode)
         while pinmuxNode != None:
@@ -452,12 +452,12 @@ class HPSGrokker(object):
         for reg, value in self.pinmux_regs.items():
             reg_count += 1
             if reg_count < pinmux_regs_count:
-                self.pinmuxHeaderBuffer.write( unicode("\t" + str(value) + ', /* ' + reg + ' */\n' ))
+                self.pinmuxHeaderBuffer.write( str("\t" + str(value) + ', /* ' + reg + ' */\n' ))
             else:
-                self.pinmuxHeaderBuffer.write( unicode("\t" + str(value) + ' /* ' + reg + ' */\n' ))
+                self.pinmuxHeaderBuffer.write( str("\t" + str(value) + ' /* ' + reg + ' */\n' ))
 
         # Write the close of the pin MUX array in the header
-        self.pinmuxHeaderBuffer.write( unicode("};" ))
+        self.pinmuxHeaderBuffer.write( str("};" ))
 
     def handleHPSClockNode(self, clockNode):
         """ A clockNode may emit a #define for the name, frequency pair
@@ -534,7 +534,7 @@ class HPSGrokker(object):
                 elif childNode.nodeName == 'peripherals':
                     self.handleHPSPeripheralNode(childNode)
                 else:
-                    print '***Error:Found unexpected HPS child node:%s' % childNode.nodeName
+                    print('***Error:Found unexpected HPS child node:%s' % childNode.nodeName)
                 childNode = xmlgrok.nextElementSibling(childNode)
 
         self.updateTemplate("DERIVED_DEVICE_FAMILY", self.derivedDeviceFamily)


### PR DESCRIPTION
Tested with generating a preloader for a DE10 nano board.

On newer systems (like Arch) getting Python2 back in-there is a bit of a hassle (even if it is possible).
Also, on newer versions of Ubuntu, this is also going to be a bit more difficult (over time).

Luckily, the conversion to Python3 is just a few lines. A 'print' statement requires parentheses, and the 'unicode()' instantiation can be converted to 'str()'. The 'unicode()' class is a derivative of 'str()', which is required in Python2 for unicode string handling; though, it's unlikely we would need to generate unicode C definitions, so 'str()' should be fine.

Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>